### PR TITLE
Replace rgl.* functions with *3d

### DIFF
--- a/R/crs.R
+++ b/R/crs.R
@@ -1451,7 +1451,7 @@ plot.crs <- function(x,
           rgl::open3d()
 
           rgl::par3d(windowRect=c(900,100,900+640,100+640))
-          rgl::rgl.viewpoint(theta = 0, phi = -70, fov = 80)
+          rgl::view3d(theta = 0, phi = -70, fov = 80)
 
           rgl::persp3d(x=x1.seq,y=x2.seq,z=z,
                        xlab=names(object$xz)[1],ylab=names(object$xz)[2],zlab="Y",

--- a/R/np.regression.glp.R
+++ b/R/np.regression.glp.R
@@ -2621,7 +2621,7 @@ plot.npglpreg <- function(x,
           rgl::open3d()
 
           rgl::par3d(windowRect=c(900,100,900+640,100+640))
-          rgl::rgl.viewpoint(theta = 0, phi = -70, fov = 80)
+          rgl::view3d(theta = 0, phi = -70, fov = 80)
 
           rgl::persp3d(x=x1.seq,y=x2.seq,z=z,
                        xlab=names(object$x)[1],ylab=names(object$x)[2],zlab="Y",

--- a/demo/radial_rgl.R
+++ b/demo/radial_rgl.R
@@ -47,7 +47,7 @@ col <- colorlut[ (num.colors-1)*(z-min(z))/(max(z)-min(z)) + 1 ]
 ## Open an rgl 3d window and use `persp3d()', a high-level function
 ## for 3D surfaces (and define the size of the window to be
 ## 640x640). The function par3d() passes in a window size (the default
-## is 256x256 which is quite small), the function rgl.viewpoint()
+## is 256x256 which is quite small), the function view3d()
 ## allows you to modify the `field of view' to get more of a
 ## `perspective' feel to the plot, while the function grid3d() adds a
 ## grid to the plot.
@@ -55,7 +55,7 @@ col <- colorlut[ (num.colors-1)*(z-min(z))/(max(z)-min(z)) + 1 ]
 open3d()
 
 par3d(windowRect=c(900,100,900+640,100+640))
-rgl.viewpoint(theta = 0, phi = -70, fov = 80)
+view3d(theta = 0, phi = -70, fov = 80)
 
 persp3d(x=x1.seq,y=x2.seq,z=z,
         xlab="X1",ylab="X2",zlab="Y",
@@ -69,8 +69,8 @@ persp3d(x=x1.seq,y=x2.seq,z=z,
 grid3d(c("x", "y+", "z"))
 
 ## You can also add other surfaces to the plot (e.g. error bounds) via
-## rgl.surface(x, y, z.ub, color="grey", alpha=.7, back="lines")
-## rgl.surface(x, y, z.lb, color="grey", alpha=.7, back="lines")
+## surface3d(x, y, z.ub, color="grey", alpha=.7, back="lines")
+## surface3d(x, y, z.lb, color="grey", alpha=.7, back="lines")
 ## where z.up and z.lb are the lower and upper bounds
 
 ## You could animate the results for 15 seconds using the line

--- a/demo/sine_rgl.R
+++ b/demo/sine_rgl.R
@@ -48,7 +48,7 @@ col <- colorlut[ (num.colors-1)*(z-min(z))/(max(z)-min(z)) + 1 ]
 ## Open an rgl 3d window and use `persp3d()', a high-level function
 ## for 3D surfaces (and define the size of the window to be
 ## 640x640). The function par3d() passes in a window size (the default
-## is 256x256 which is quite small), the function rgl.viewpoint()
+## is 256x256 which is quite small), the function view3d()
 ## allows you to modify the `field of view' to get more of a
 ## `perspective' feel to the plot, while the function grid3d() adds a
 ## grid to the plot.
@@ -56,7 +56,7 @@ col <- colorlut[ (num.colors-1)*(z-min(z))/(max(z)-min(z)) + 1 ]
 open3d()
 
 par3d(windowRect=c(900,100,900+640,100+640))
-rgl.viewpoint(theta = 0, phi = -70, fov = 80)
+view3d(theta = 0, phi = -70, fov = 80)
 
 persp3d(x=x1.seq,y=x2.seq,z=z,
         xlab="X1",ylab="X2",zlab="Y",
@@ -70,8 +70,8 @@ persp3d(x=x1.seq,y=x2.seq,z=z,
 grid3d(c("x", "y+", "z"))
 
 ## You can also add other surfaces to the plot (e.g. error bounds) via
-## rgl.surface(x, y, z.ub, color="grey", alpha=.7, back="lines")
-## rgl.surface(x, y, z.lb, color="grey", alpha=.7, back="lines")
+## surface3d(x, y, z.ub, color="grey", alpha=.7, back="lines")
+## surface3d(x, y, z.lb, color="grey", alpha=.7, back="lines")
 ## where z.up and z.lb are the lower and upper bounds
 
 ## You could animate the results for 15 seconds using the line


### PR DESCRIPTION
An upcoming release of `rgl` will deprecate a large number of `rgl.*` functions in favour of the `*3d` versions.  This PR makes the substitutions needed to avoid warnings when that happens.  I think the displays should remain the same, but it is possible some defaults (e.g. background colour) are changed.